### PR TITLE
feat(dashboard): store and display saved YouTube links with metadata

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,8 +89,11 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.3")
     implementation(libs.androidx.annotation)
 
+// ✅ DataStore (Preferences 기반 저장)
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
 
-
+    // 이미지 로딩 라이브러리 Coil (Compose 지원)
+    implementation("io.coil-kt:coil-compose:2.5.0")
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/example/barta/DashboardScreen.kt
+++ b/app/src/main/java/com/example/barta/DashboardScreen.kt
@@ -1,12 +1,64 @@
 package com.example.barta
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.example.barta.data.Store.LinkStore
+import com.example.barta.ui.theme.suiteFontTypography
+import com.example.barta.util.extractVideoId
+import androidx.compose.ui.draw.clip
 
 @Composable
 fun DashboardScreen(navController: NavController, modifier: Modifier = Modifier) {
-    Text("여기는 대쉬보드입니다.")
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        LinkStore.loadFromDataStore(context)
+    }
+
+    Column(modifier = Modifier.padding(16.dp)) {
+        Text("저장된 링크", style = suiteFontTypography.h4)
+        Spacer(Modifier.height(16.dp))
+
+        LinkStore.youtubeHistory.forEach { saved ->
+            val videoId = extractVideoId(saved.url)
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { navController.navigate("player/$videoId") }
+                    .padding(8.dp)
+            ) {
+                AsyncImage(
+                    model = ImageRequest.Builder(context)
+                        .data(saved.thumbnailUrl)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = saved.title,
+                    modifier = Modifier
+                        .size(96.dp)
+                        .aspectRatio(16f / 9f)
+                        .clip(RoundedCornerShape(8.dp)),
+                    contentScale = ContentScale.Crop
+                )
+                Spacer(Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(saved.title, style = suiteFontTypography.h6)
+                    Text(saved.savedAt, style = suiteFontTypography.body2)
+                }
+            }
+            Divider()
+        }
+    }
 }

--- a/app/src/main/java/com/example/barta/HomeScreen.kt
+++ b/app/src/main/java/com/example/barta/HomeScreen.kt
@@ -24,11 +24,14 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.example.barta.data.Store.LinkStore
 import com.example.barta.ui.theme.LocalBartaPalette
 import com.example.barta.ui.theme.suiteFontTypography
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.animation.core.animateDpAsState
 import android.view.ViewTreeObserver
+import androidx.compose.ui.platform.LocalContext
+
 
 fun extractVideoId(url: String): String {
     val regex = Regex("(?:v=|be/|embed/)([\\w-]{11})")
@@ -38,6 +41,7 @@ fun extractVideoId(url: String): String {
 @Composable
 fun HomeScreen(navController: NavController, modifier: Modifier = Modifier) {
     val color = LocalBartaPalette.current
+    val context = LocalContext.current
     var url by remember { mutableStateOf("") }
     val focusManager = LocalFocusManager.current
     val scrollState = rememberScrollState()
@@ -236,6 +240,7 @@ fun HomeScreen(navController: NavController, modifier: Modifier = Modifier) {
                 onClick = {
                     val videoId = extractVideoId(url)
                     if (videoId.isNotEmpty()) {
+                        LinkStore.addUrl(url, context)  // ✅ 저장
                         focusManager.clearFocus()
                         navController.navigate("player/$videoId")
                     }

--- a/app/src/main/java/com/example/barta/data/Store/LinkStore.kt
+++ b/app/src/main/java/com/example/barta/data/Store/LinkStore.kt
@@ -1,0 +1,78 @@
+package com.example.barta.data.Store
+
+import android.content.Context
+import androidx.datastore.preferences.preferencesDataStore
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import com.example.barta.util.fetchYoutubeMeta
+import com.example.barta.util.YoutubeVideoMeta
+import com.example.barta.util.extractVideoId
+import com.example.barta.BuildConfig
+
+
+object LinkStore {
+    private val Context.dataStore by preferencesDataStore(name = "barta_links")
+    private val KEY_LINK_SET = stringSetPreferencesKey("youtube_links")
+
+    var youtubeHistory = mutableListOf<SavedLink>()
+
+    fun addUrl(url: String, context: Context) {
+        val meta = fetchYoutubeMetaBlocking(url)
+        val time = getCurrentFormattedTime()
+        val saved = SavedLink(
+            url = url,
+            title = meta?.title ?: "제목 불러오기 실패",
+            savedAt = time,
+            thumbnailUrl = meta?.thumbnailUrl ?: ""
+        )
+
+        if (!youtubeHistory.any { it.url == url }) {
+            youtubeHistory.add(0, saved)
+            saveToDataStore(context)
+        }
+    }
+
+    private fun saveToDataStore(context: Context) {
+        runBlocking {
+            context.dataStore.edit { prefs ->
+                val set = youtubeHistory.map {
+                    "${it.url}||${it.title}||${it.savedAt}||${it.thumbnailUrl}"
+                }.toSet()
+                prefs[KEY_LINK_SET] = set
+            }
+        }
+    }
+
+    fun loadFromDataStore(context: Context) {
+        runBlocking {
+            val prefs = context.dataStore.data.first()
+            youtubeHistory = prefs[KEY_LINK_SET]?.map { str: String ->
+                val parts = str.split("||")
+                SavedLink(
+                    url = parts.getOrElse(0) { "" },
+                    title = parts.getOrElse(1) { "제목 없음" },
+                    savedAt = parts.getOrElse(2) { "시간 없음" },
+                    thumbnailUrl = parts.getOrElse(3) { "" }
+                )
+            }?.toMutableList() ?: mutableListOf()
+        }
+    }
+
+    private fun getCurrentFormattedTime(): String {
+        val formatter = java.text.SimpleDateFormat("yyyy.MM.dd HH:mm", java.util.Locale.getDefault())
+        return formatter.format(java.util.Date())
+    }
+
+    private fun fetchYoutubeMetaBlocking(url: String): YoutubeVideoMeta? {
+        val videoId = extractVideoId(url)
+        return try {
+            runBlocking {
+                fetchYoutubeMeta(videoId, BuildConfig.YOUTUBE_API_KEY)
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/example/barta/data/Store/SavedLink.kt
+++ b/app/src/main/java/com/example/barta/data/Store/SavedLink.kt
@@ -1,0 +1,8 @@
+package com.example.barta.data.Store
+
+data class SavedLink(
+    val url: String,
+    val title: String,
+    val savedAt: String,
+    val thumbnailUrl: String
+)

--- a/app/src/main/java/com/example/barta/util/STTController.kt
+++ b/app/src/main/java/com/example/barta/util/STTController.kt
@@ -88,7 +88,7 @@ class STTController(
     }
 
     fun destroy() {
-        speechRecognizer.destroy()
-        handler?.removeCallbacks(commandTimeoutRunnable!!)
+        speechRecognizer?.destroy()
+        handler?.removeCallbacks(commandTimeoutRunnable ?: return)
     }
 }

--- a/app/src/main/java/com/example/barta/util/YoutubeApi.kt
+++ b/app/src/main/java/com/example/barta/util/YoutubeApi.kt
@@ -1,0 +1,63 @@
+package com.example.barta.util
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+import kotlinx.coroutines.*
+
+@Serializable
+data class YoutubeApiResponse(val items: List<YoutubeVideoItem>)
+
+@Serializable
+data class YoutubeVideoItem(val snippet: YoutubeSnippet)
+
+@Serializable
+data class YoutubeSnippet(
+    val title: String,
+    val description: String,
+    val thumbnails: YoutubeThumbnails
+)
+
+@Serializable
+data class YoutubeThumbnails(val medium: YoutubeThumbnailInfo)
+
+@Serializable
+data class YoutubeThumbnailInfo(val url: String)
+
+data class YoutubeVideoMeta(
+    val title: String,
+    val thumbnailUrl: String
+)
+
+suspend fun fetchYoutubeMeta(videoId: String, apiKey: String): YoutubeVideoMeta? {
+    val client = HttpClient(CIO) {
+        install(ContentNegotiation) {
+            json(Json { ignoreUnknownKeys = true })
+        }
+    }
+
+    val url = "https://www.googleapis.com/youtube/v3/videos?part=snippet&id=$videoId&key=$apiKey"
+
+    return try {
+        val response: HttpResponse = client.get(url)
+        val body: YoutubeApiResponse = response.body()
+        val snippet = body.items.firstOrNull()?.snippet
+        snippet?.let {
+            YoutubeVideoMeta(
+                title = it.title,
+                thumbnailUrl = it.thumbnails.medium.url
+            )
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+        null
+    } finally {
+        client.close()
+    }
+}

--- a/app/src/main/java/com/example/barta/util/YoutubeUtils.kt
+++ b/app/src/main/java/com/example/barta/util/YoutubeUtils.kt
@@ -1,0 +1,11 @@
+package com.example.barta.util
+
+// ✅ 클래스 없이 바로 top-level 함수로 작성
+fun extractVideoId(url: String): String {
+    val regex = Regex("(?:v=|be/|embed/)([\\w-]{11})")
+    return regex.find(url)?.groupValues?.get(1) ?: ""
+}
+
+fun extractTitleFromDescription(description: String): String {
+    return description.lines().firstOrNull()?.take(50) ?: "제목 없음"
+}


### PR DESCRIPTION
- 입력된 유튜브 링크를 저장하고 대시보드에서 리스트로 출력
- 링크와 함께 썸네일 이미지, 저장 날짜를 함께 저장
- Dashboard 화면에서 저장된 링크들을 불러와 UI에 표시