### PR TITLE
chore: rename package Store to store for consistency

### DIFF
--- a/app/src/main/java/com/example/barta/DashboardScreen.kt
+++ b/app/src/main/java/com/example/barta/DashboardScreen.kt
@@ -1,6 +1,5 @@
 package com.example.barta
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -15,7 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import com.example.barta.data.Store.LinkStore
+import com.example.barta.data.store.LinkStore
 import com.example.barta.ui.theme.suiteFontTypography
 import com.example.barta.util.extractVideoId
 import androidx.compose.ui.draw.clip

--- a/app/src/main/java/com/example/barta/HomeScreen.kt
+++ b/app/src/main/java/com/example/barta/HomeScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import com.example.barta.data.Store.LinkStore
+import com.example.barta.data.store.LinkStore
 import com.example.barta.ui.theme.LocalBartaPalette
 import com.example.barta.ui.theme.suiteFontTypography
 import androidx.compose.foundation.layout.WindowInsets

--- a/app/src/main/java/com/example/barta/data/store/LinkStore.kt
+++ b/app/src/main/java/com/example/barta/data/store/LinkStore.kt
@@ -1,4 +1,4 @@
-package com.example.barta.data.Store
+package com.example.barta.data.store
 
 import android.content.Context
 import androidx.datastore.preferences.preferencesDataStore

--- a/app/src/main/java/com/example/barta/data/store/SavedLink.kt
+++ b/app/src/main/java/com/example/barta/data/store/SavedLink.kt
@@ -1,4 +1,4 @@
-package com.example.barta.data.Store
+package com.example.barta.data.store
 
 data class SavedLink(
     val url: String,


### PR DESCRIPTION
- Java/Kotlin 패키지 네이밍 규칙에 맞게 Store → store로 변경
- 대소문자 통일을 통해 파일 시스템 충돌 방지 및 일관성 유지